### PR TITLE
use None as default value for whatis + minor style fixes

### DIFF
--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -155,7 +155,7 @@ DEFAULT_CONFIG = {
     'exts_list': [[], 'List with extensions added to the base installation', EXTENSIONS],
 
     # MODULES easyconfig parameters
-    'whatis': [[], "List of brief (one line) package description entries", MODULES],
+    'whatis': [None, "List of brief (one line) package description entries", MODULES],
     'modaliases': [{}, "Aliases to be defined in module file", MODULES],
     'modextrapaths': [{}, "Extra paths to be prepended in module file", MODULES],
     'modextravars': [{}, "Extra environment variables to be added to module file", MODULES],

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -163,7 +163,8 @@ class ModuleGeneratorTcl(ModuleGenerator):
         description = "%s - Homepage: %s" % (self.app.cfg['description'], self.app.cfg['homepage'])
 
         whatis = self.app.cfg['whatis']
-        if not whatis:
+        if whatis is None:
+            # default: include single 'whatis' statement with description as contents
             whatis = [description]
 
         lines = [
@@ -194,7 +195,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
             'name': self.app.name,
             'version': self.app.version,
             'description': description,
-            'whatis_lines': "\n".join(("module-whatis {%s}" % line) for line in whatis),
+            'whatis_lines': '\n'.join(["module-whatis {%s}" % line for line in whatis]),
             'installdir': self.app.installdir,
         }
 
@@ -338,7 +339,8 @@ class ModuleGeneratorLua(ModuleGenerator):
         description = "%s - Homepage: %s" % (self.app.cfg['description'], self.app.cfg['homepage'])
 
         whatis = self.app.cfg['whatis']
-        if not whatis:
+        if whatis is None:
+            # default: include single 'whatis' statement with description as contents
             whatis = [description]
 
         lines = [
@@ -360,7 +362,7 @@ class ModuleGeneratorLua(ModuleGenerator):
             'name': self.app.name,
             'version': self.app.version,
             'description': description,
-            'whatis_lines': "\n".join(("whatis([[%s]])" % line) for line in whatis),
+            'whatis_lines': '\n'.join(["whatis([[%s]])" % line for line in whatis]),
             'installdir': self.app.installdir,
             'homepage': self.app.cfg['homepage'],
         }

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -107,7 +107,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.assertEqual(desc, expected)
 
         # Test description with list of 'whatis' strings
-        self.eb.cfg.update('whatis', ['foo', 'bar'])
+        self.eb.cfg['whatis'] = ['foo', 'bar']
         if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
             expected = '\n'.join([
                 "#%Module",


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-framework/pull/1271

@geimer: using a mutable value like a empty list can have nasty side-effects, so we should try and avoid it if we can; we are guilty of that sin in other places (cfr. `modaliases`, etc.), but that should be no reason to make matters worse :-)

So, let's use `None` as a default for `whatis`.

With this included, https://github.com/hpcugent/easybuild-framework/pull/1271 is good to go in imho.
