### PR TITLE
pass down default optarch value for AAarch64 & GCC 6.x rather than updating class constant

### DIFF
--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -271,8 +271,13 @@ class Compiler(Toolchain):
             self.variables.nextend(var, flags)
             self.variables.nextend(var, fflags)
 
-    def _set_optimal_architecture(self):
-        """ Get options for the current architecture """
+    def _set_optimal_architecture(self, default_optarch=None):
+        """
+        Get options for the current architecture
+
+        :param default_optarch: default value to use for optarch, rather than using default value based on architecture
+                                (--optarch and --optarch=GENERIC still override this value)
+        """
         optarch = None
         # --optarch is specified with flags to use
         if build_option('optarch') is not None and build_option('optarch') != OPTARCH_GENERIC:
@@ -281,7 +286,10 @@ class Compiler(Toolchain):
         elif build_option('optarch') == OPTARCH_GENERIC:
             if self.arch in (self.COMPILER_GENERIC_OPTION or []):
                 optarch = self.COMPILER_GENERIC_OPTION[self.arch]
-        # no --optarch specified
+        # specified optarch default value
+        elif default_optarch:
+            optarch = default_optarch
+        # no --optarch specified, no default value specified
         elif self.arch in (self.COMPILER_OPTIMAL_ARCHITECTURE_OPTION or []):
             optarch = self.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[self.arch]
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -358,17 +358,23 @@ class ToolchainTest(EnhancedTestCase):
         st.get_cpu_model = lambda: 'ARM Cortex-A53'
         st.get_cpu_vendor = lambda: st.ARM
         tc = self.get_toolchain("GCC", version="4.7.2")
+        tc.set_options({})
         tc.prepare()
-        self.assertEqual(tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch], 'mcpu=cortex-a53')
+        self.assertEqual(tc.options.options_map['optarch'], 'mcpu=cortex-a53')
+        self.assertTrue('-mcpu=cortex-a53' in os.environ['CFLAGS'])
+
+        tc = self.get_toolchain("GCCcore", version="6.2.0")
+        tc.set_options({})
+        tc.prepare()
+        self.assertEqual(tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch], 'mcpu=native')
+        self.assertTrue('-mcpu=native' in os.environ['CFLAGS'])
 
         st.get_cpu_model = lambda: 'ARM Cortex-A53 + Cortex-A72'
         tc = self.get_toolchain("GCC", version="4.7.2")
+        tc.set_options({})
         tc.prepare()
-        self.assertEqual(tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch], 'mcpu=cortex-a72.cortex-a53')
-
-        tc = self.get_toolchain("GCCcore", version="6.2.0")
-        tc.prepare()
-        self.assertEqual(tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch], 'mcpu=native')
+        self.assertEqual(tc.options.options_map['optarch'], 'mcpu=cortex-a72.cortex-a53')
+        self.assertTrue('-mcpu=cortex-a72.cortex-a53' in os.environ['CFLAGS'])
 
     def test_misc_flags_unique_fortran(self):
         """Test whether unique Fortran compiler flags are set correctly."""


### PR DESCRIPTION
@geimer this fixes the problem you have in https://github.com/hpcugent/easybuild-framework/pull/1974

The issue was that you were fiddling with the class constant `COMPILER_OPTIMAL_ARCHITECTURE_OPTION` (probably following my suggestion...)
The default values in that `dict` value are only reset if class is redefined, i.e. if the `gcc.py` module is reloaded (which doesn't happen).

Instead, I enhanced the `_set_optimal_architecture` method to support passing down a custom default value for `optarch`. Constants are named 'constants' for a reason. ;-)

You may not feel like it, but you were lucky to run into this. If you would've tested with GCC 6.x first, and then older versions later, the tests would've missed this bug. Also, you would only run into the bug when using `eb` when building stuff on `Aarch64` with two (or more) different GCC versions in the same session (with one older than v6, one newer), which is probably a rare use case.

So, the bug would've been quite subtle in practice... Yaay for tests! \o/ ;-)

Let me know if there's anything else I can do to help out with https://github.com/hpcugent/easybuild-framework/pull/1974